### PR TITLE
correct mistake

### DIFF
--- a/content/collections/modifiers/underscored.md
+++ b/content/collections/modifiers/underscored.md
@@ -18,5 +18,5 @@ string: Please and thank you
 ```
 
 ```.language-output
-please-and-thank-you
+please_and_thank_you
 ```


### PR DESCRIPTION
hyphens were used in place of underscores
