### PR TITLE
Collection routes `locations` example repair

### DIFF
--- a/content/pages/1.guides/6.urls-and-routing/index.md
+++ b/content/pages/1.guides/6.urls-and-routing/index.md
@@ -130,8 +130,8 @@ collections:
 
 Any time you're looping through the collection to render its data, each entry's `{{ url }}` will match to this format. For the `locations` collection, you could see URLs like the following:
 
-- `http://example.com/stores/saratoga-springs/new-york`
-- `http://example.com/stores/miami/florida`
+- `http://example.com/stores/new-york/saratoga-springs`
+- `http://example.com/stores/florida/miami`
 
 And in the blog you might see this:
 


### PR DESCRIPTION
Or you could change `locations: /stores/{state}/{city}` to `locations: /stores/{city}/{state}` instead. Either way, just so they match up, ja?
