### PR TITLE
Q: `php please search:update` in docs?

### DIFF
--- a/content/pages/1.guides/3.content-types/index.md
+++ b/content/pages/1.guides/3.content-types/index.md
@@ -175,3 +175,4 @@ You can create listings and single view URLs, like with Entries, and group them 
 [image-api]: #
 [taxonomy-fieldtype]: #
 [guide-users]: #
+


### PR DESCRIPTION
(Please ignore the "edit" of an extra line at the end of the page. I just couldn't find any other way to ask a question or make a comment without actually changing the visible text.)

Here's the real issue:

Note that the words "mount" and "mounted" both appear on this page. However, search (`http://docs.talonsbeard.com/search?q=mount`) only finds a hit on `http://docs.talonsbeard.com/docs/tags/entries`.

Hence my question: Is it time for a `php please search:update` or something equivalent ?
