### PR TITLE
Indentation error causes misspellings

### DIFF
--- a/content/collections/tags/user-logout_url.md
+++ b/content/collections/tags/user-logout_url.md
@@ -7,8 +7,8 @@ parameters:
     type: string
     description: >
        Where the user should be redirected
-      after logging out. Defaults to the home
-      page.
+       after logging out. Defaults to the home
+       page.
 id: 232b878c-18da-4d01-80f3-a85fcdf65ed8
 ---
 ## Example {#example}


### PR DESCRIPTION
What we see on the screen is below (missing "a" in "after", missing "p" in "page"):

> Where the user should be redirected fter logging out. Defaults to the home age.

Not sure if I fixed it the right way, but at least I've highlighted the error so YOU can fix it! :-)
