### PR TITLE
Explicitly list valid `width` values

### DIFF
--- a/content/pages/2.docs/4.fieldtypes/index.md
+++ b/content/pages/2.docs/4.fieldtypes/index.md
@@ -21,7 +21,7 @@ options:
   -
     name: width
     type: int
-    description: The fields's width layout, in percentages (e.g. `100`, `50`)
+    description: The fields's width layout, in percentages (e.g., `100`, `75`, `66`, `50`, `33`, or `25`; other values are ignored. )
   -
     name: validate
     type: string


### PR DESCRIPTION
...since any other values (e.g., `60`, `40`) don't seem to work, and revert to `100`, you might as well say so.
