### PR TITLE
Remove erroneous `previous_page`, `next_page` from middle of `paginat…

### DIFF
--- a/content/collections/tags/collection.md
+++ b/content/collections/tags/collection.md
@@ -306,8 +306,6 @@ The `paginate` variable will become available to you. This is an array containin
 | `total_items` |	The total number of entries.
 | `total_pages` |	The number of paginated pages.
 | `current_page` |	The current paginated page. (ie. the x in the ?page=x param)
-| `previous_page` |	The URL to the previous page.
-| `next_page` |	The URL to the next page.
 | `auto_links` |	Outputs a Twitter Bootstrap ready list of links.
 | `links` |	Contains data for you to construct a custom list of links.
 | `links:all` |	An array of all the pages. You can loop over this and output {{ url }} and {{ page }}.


### PR DESCRIPTION
…e` variables table

Top two line of the table are correct.
