### PR TITLE
Blanks space "gotcha" got ME!

### DIFF
--- a/content/collections/tags/partial.md
+++ b/content/collections/tags/partial.md
@@ -32,7 +32,7 @@ The most common usage of a partial is to add a header or navigation into a layou
 </html>
 ```
 
-The `{{ partial:header }}` tag would output the contents of `site/themes/theme_name/partials/header.html`.
+The `{{ partial:header }}` tag would output the contents of `site/themes/theme_name/partials/header.html`. Note no space is allowed between the tag’s trailing colon your partial’s filename. I.e., `{{ partial:header }}` works, whereas `{{ partial: header }}` does not.
 
 Splitting your templates up into partials is a nice way to keep things clean and organized.
 


### PR DESCRIPTION
My CSS habits got the best of me, and I had to spend quiiiiiite a while chasing this one down. Thus, I thought it might be worthwhile to save others some time and trouble by roping off this potential pitfall with some kind of a note in the docs. Essentially: "You can't have a blank space after the colon in a partial call!" (Please feel free to choose better wording and/or placement.)
