### PR TITLE
Remove whitespace in JS lines for template

### DIFF
--- a/content/pages/2.addons/2.anatomy/4.fieldtypes/index.md
+++ b/content/pages/2.addons/2.anatomy/4.fieldtypes/index.md
@@ -58,13 +58,13 @@ Vue.component('password_toggle-fieldtype', {
         }
     }, 
 
-    template: '
-      <div>
-        <input :type="inputType" v-model="data" />
-        <input type="checkbox" :id="name" v-model="show" />
-        <label :for="name">Show password</label>
-      </div>
-    '
+    template: '' +
+      '<div>' +
+        '<input :type="inputType" v-model="data" />' +
+        '<input type="checkbox" :id="name" v-model="show" />' +
+        '<label :for="name">Show password</label>' +
+      '</div>' +
+    ''
 
 });
 ```


### PR DESCRIPTION
Maybe it's just me, but I've got an add-on doing this:

```
template: '' +
    '<div>' +
        '<input type="text" v-model="data" class="form-control" readonly/>' +
    '</div>' +
  '',
```

and doing it like this (as seen in docs), doesn't work:

```
template: '
    <div>
        <input type="text" v-model="data" class="form-control" readonly/>
    </div>
  ',
```
