### PR TITLE
scotch typo

### DIFF
--- a/content/pages/1.reference/5.conditions/index.md
+++ b/content/pages/1.reference/5.conditions/index.md
@@ -108,7 +108,7 @@ That would filter down to this:
 - Rye Whiskey
 ```
 
-We can't forget about Scotch, but since its spelled `whiskey`, our condition filters it out.
+We can't forget about Scotch, but since its spelled `whisky`, our condition filters it out.
 
 Let's use a regular expression to make that `e` optional.
 


### PR DESCRIPTION
was confusing since it was written in the example as the other whiskEys, not as it's spelled in the list, whisky.
