### PR TITLE
Example tweak

### DIFF
--- a/content/collections/modifiers/truncate.md
+++ b/content/collections/modifiers/truncate.md
@@ -14,7 +14,7 @@ advice: >
 ```
 
 ```
-{{ advice | safe_truncate:90:... }}
+{{ advice | truncate:90:... }}
 ```
 
 ```.language-output


### PR DESCRIPTION
It showed `safe-truncate`, but should be just `truncate`.
