### PR TITLE
Fix typo in docs for theming

### DIFF
--- a/content/collections/docs/theming.md
+++ b/content/collections/docs/theming.md
@@ -152,7 +152,7 @@ layout: landing_b
 ---
 ```
 
-This will use the code from `promo.html` within your current theme’s `layouts` folder. If that file doesn’t exist, Statamic will graciously display an error.
+This will use the code from `landing_b.html` within your current theme’s `layouts` folder. If that file doesn’t exist, Statamic will graciously display an error.
 
 #### Per Folder
 


### PR DESCRIPTION
On this page:
https://docs.statamic.com/theming#choosing-layouts

The example for using a custom layout has YAML that doesn't match the given file name.