### PR TITLE
Fixed a typo 'a an event' on the Addon > Event Listeners page:

### DIFF
--- a/content/pages/7.addons/2.classes/5.event-listeners/index.md
+++ b/content/pages/7.addons/2.classes/5.event-listeners/index.md
@@ -10,7 +10,7 @@ Listeners should define a list of events mapped to the class methods. When match
 
 ## Generating an Event Listener Class {#generating}
 
-You can generate a an event listener class file with a console command.
+You can generate an event listener class file with a console command.
 
 ``` .language-console
 php please make:listener AddonName


### PR DESCRIPTION
See the text below 'Example Listener' heading on this page: https://docs.statamic.com/addons/classes/event-listeners

I've removed the a in the 'a an event'