### PR TITLE
Add a missing subhead anchor…

### DIFF
--- a/content/collections/fieldtypes/pages.md
+++ b/content/collections/fieldtypes/pages.md
@@ -24,7 +24,7 @@ pages:
   - 134jk1h78dfas
 ```
 
-## Templating {templating}
+## Templating {#templating}
 
 Use the [Relate tag](/tags/relate) to loop through the IDs and fetch the content data.
 

--- a/content/collections/fieldtypes/pages.md
+++ b/content/collections/fieldtypes/pages.md
@@ -24,7 +24,7 @@ pages:
   - 134jk1h78dfas
 ```
 
-## Templating
+## Templating {templating}
 
 Use the [Relate tag](/tags/relate) to loop through the IDs and fetch the content data.
 


### PR DESCRIPTION
…to allow page's TOC skip link to work (assuming that's the correct anchor text?)