### PR TITLE
Update nav.md

### DIFF
--- a/content/collections/tags/nav.md
+++ b/content/collections/tags/nav.md
@@ -161,10 +161,10 @@ has been removed in favor of the following workflow.
 2. In your `nav` tag, use the [conditions syntax](/conditions) to remove any hidden pages:
 
    ```
-   {{ nav from="/" is_hidden:isnt_set="true" }}
+   {{ nav from="/" is_hidden:isnt="true" }}
        ...
    {{ /nav }}
    ```
 
-   This is saying, only show pages where the `is_hidden` field _isn't set_. That will leave you with unhidden pages.
+   This is saying, only show pages where the `is_hidden` field _isn't set to true_. That will leave you with unhidden pages.
    Remember, the field can be named whatever you want.


### PR DESCRIPTION
Using `isnt_set` works until you toggle the setting to true, safe and then toggle it off again. Then `is_hidden` is set to false, and that is set but we still do not want the nav item to show up. Using `isnt` makes this behave as expected.