### PR TITLE
Update installing.md

### DIFF
--- a/content/collections/docs/installing.md
+++ b/content/collections/docs/installing.md
@@ -123,11 +123,12 @@ Done.
 
 ### Step 2: Set permissions {#permissions}
 
-Every Statamic instance needs full write access to the following 3 directories recursively (e.g. all their subfolders and files).
+Every Statamic instance needs full write access to the following 4 directories recursively (e.g. all their subfolders and files).
 
 - `site`
 - `local`
 - `statamic`
+- `assets`
 
 In order to have write access, the necessary permissions depend on which system user PHP is running as and which user owns the files and folders. Here are some recommendations. When in doubt, just use `777`:
 


### PR DESCRIPTION
Docs list 3 directories that need recursive permissions however, the terminal command lists 4 directories (it includes assets directory). Updating this to list 4 directories in both areas of the page.