### PR TITLE
{{ current_time }} out?

### DIFF
--- a/content/collections/docs/migrating.md
+++ b/content/collections/docs/migrating.md
@@ -40,7 +40,7 @@ Each of these changes may require a little bit of work.
 ### Renamed Variables {#renamed-variables}
 
 - `{{ layout_content }}` is now `{{ template_content }}` because it's the actual contents of the template. Feels so much more natural.
-- ``{{ current_time }}``
+- `{{ current_date }}`  is now `{{ now }}` 
 
 ### Removed Variables {#removed-variables}
 


### PR DESCRIPTION
(copy/pasted from Slack) idgs [11:55 AM] 
JOBTW, I happened to notice https://docs.statamic.com/migrating#renamed-variables lists `{{ current_time }}` all by its lonesome (no mention of a v2 replacement). Howevs, https://v1.statamic.com/learn/documentation/global-variables only lists `current_date` (which I assume is now `{{ now }}` (?)