### PR TITLE
Completed fieldtype Pages

### DIFF
--- a/content/collections/fieldtypes/relate.md
+++ b/content/collections/fieldtypes/relate.md
@@ -32,5 +32,6 @@ You can relate any of the base [Content Types](/content-types), each of which wi
 
 - [Taxonomy](/fieldtypes/taxonomy) - for Taxonomy Terms
 - [Collection](/fieldtypes/collection) - for Entries
+- [Pages](/fieldtypes/pages) - for Pages
 - [Users](/fieldtypes/users) - for Users
 - [Assets](/fieldtypes/assets) - for Assets (it doesn't extend this Relate fieldtype)


### PR DESCRIPTION
It was missing in the list of Relate Implementations.

_Globals_ doesn't seem to exist?