### PR TITLE
Widget vs. Widgets (and more!)

### DIFF
--- a/content/pages/7.addons/index.md
+++ b/content/pages/7.addons/index.md
@@ -28,7 +28,7 @@ An addon can contain a number of classes, each. It can be made up of one of them
 - [API][api] allows you to interact with other addons, and them with you.
 - [Controllers][controllers] allow you to create pages in the control panel.
 - [Filters][filters] let you perform more complicated filtering of content on certain tags.
-- [Widgets][widgets] can be added to your Control Panel's dashboard.
+- [Widgets][widget] can be added to your Control Panel's dashboard.
 
 
 By using combinations of these aspects in your addons, you can create some truly fascinating results. And remember, all of these aspects are simply PHP, so anything you can do with PHP is possible here.


### PR DESCRIPTION
The link that works is https://docs.statamic.com/addons/classes/widget (no "s"); https://docs.statamic.com/addons/classes/widgets (with an "s") gives you a 404.

IMHO, that's backwards. You should change the working link to the one WITH the "s" and fix the links to suit. The link-text has it with an "s" in both places on the page—it'd be only natural to go to a likewise "plural" URL, if you know what I mean.

So what you REALLY want is the fix I'm talking about above, and not the typo-correction you'd get with a simple merge, here. Right?