### PR TITLE
.dev domain is reserved

### DIFF
--- a/content/collections/kb/trial-mode.md
+++ b/content/collections/kb/trial-mode.md
@@ -11,7 +11,7 @@ Our [article about how licensing works][licensing] explains how we define a publ
 
 This allows you to try out Statamic and even develop the site until you're ready to purchase a license.
 
-What we recommend is to run Statamic locally on a `mysite.dev` domain. Then, when you're ready: purchase a license,
+What we recommend is to run Statamic locally on a `mysite.test` domain. Then, when you're ready: purchase a license,
 drop in the key, and deploy your site.
 
 [licensing]: /licensing


### PR DESCRIPTION
.dev is reserved by Google and since Chrome 63 (Dec 2017) force redirected to https via a preloaded HTTP Strict Transport Security (HSTS) header.