### PR TITLE
Minor typo in 'numbrer' in pages.md

### DIFF
--- a/content/collections/docs/pages.md
+++ b/content/collections/docs/pages.md
@@ -17,7 +17,7 @@ In the Control Panel, pages are represented by a navigation tree. They can be dr
 
 Page files themselves are kept in `site/content/pages` and each consists of a folder and an `index.md` file.
 
-Their **order** is determined by the `order key` (a numbrer followed by a period) before the rest of the filename. The order key is stripped out of the URL automatically. You can set these order keys yourself on the file level, or order them via drag-and-drop in the Control Panel. The choice is yours, but the Control Panel is probably faster and simpler.
+Their **order** is determined by the `order key` (a number followed by a period) before the rest of the filename. The order key is stripped out of the URL automatically. You can set these order keys yourself on the file level, or order them via drag-and-drop in the Control Panel. The choice is yours, but the Control Panel is probably faster and simpler.
 
 Let's look at some examples.
 


### PR DESCRIPTION
'numbrer' becomes 'number'.

Please note that the image '/assets/img/screenshots/cp-page-tree.png' referenced on this page is also missing from the server, or of course the location/filename is incorrect).