### PR TITLE
Fix typo

### DIFF
--- a/content/pages/7.addons/8.events/index.md
+++ b/content/pages/7.addons/8.events/index.md
@@ -165,7 +165,7 @@ public function handle(Submission $submission)
     return [
         'submission' => $submission,
         'errors' => []
-    ]
+    ];
 }
 ```
 


### PR DESCRIPTION
Small syntax error in code example