### PR TITLE
Add missing list modifier

### DIFF
--- a/content/collections/modifiers/list
+++ b/content/collections/modifiers/list
@@ -1,0 +1,22 @@
+---
+types:
+  - array
+  - markup
+id: eed4c5bc-0923-4f54-ad37-ca9a3384e1e0
+---
+Turn a simple array into a comma delimited list with no comma after the last item.
+
+```.language-yaml
+things:
+  - batman
+  - zombies
+  - scrunchies
+```
+
+```
+{{ things | list }}
+```
+
+```.language-output
+batman, zombies, scrunchies
+```


### PR DESCRIPTION
`list` works as a modifier but isn't in the docs