### PR TITLE
Update user-register_form.md

### DIFF
--- a/content/collections/tags/user-register_form.md
+++ b/content/collections/tags/user-register_form.md
@@ -65,6 +65,6 @@ Additional fields will be validated as per your fieldset `validate` rules.
 
 ### New user roles
 
-Most of the time, new members will need some roles assigned to them so that they can do different things on your site. You get to choose these roles with the `new_user_roles` array in your `site/settings/users.yaml` file. When a user successfully registers as a member, their account will automatically be assigned the roles in this list.
+Most of the time, new members will need some roles assigned to them so that they can do different things on your site. You get to choose these roles by adding the `id`s of the roles, in an array called `new_user_roles` in your `site/settings/users.yaml` file. When a user successfully registers as a member, their account will automatically be assigned the roles in this list.
 
 It’s best to remember that these are _starting_ roles for the user. You can later either manually add roles to users in their files, update their account through the Control Panel, or have add-ons automatically add or remove roles as needed when users perform certain tasks.


### PR DESCRIPTION
state that the id of a role must be added to new_user_roles, not the slug (as seems more logical to me)