### PR TITLE
Clarify multiple parameters in macros

### DIFF
--- a/content/collections/modifiers/macro.md
+++ b/content/collections/modifiers/macro.md
@@ -27,3 +27,19 @@ title: Actually i don't know what we're talking about.
 ```.language-output
 I Don't Know What We're Talking&nbsp;About
 ```
+
+When passing multiple parameters to a modifier, you'll need to pop down into a simple list:
+
+```.language-yaml
+# /site/theme/<your_theme>/settings/macros.yaml
+excerpt:
+  safe_truncate: 
+    - 175
+    - ...
+```
+
+This is equivalent to:
+
+```
+{{ content | safe_truncate:175:... }}
+```


### PR DESCRIPTION
The existing documentation doesn't make it clear how to have multiple modifier parameters in a macro, even though Statamic supports this. Although a little experimentation can reveal the solution, I thought I might save someone a few minutes to have that right in the docs.