### PR TITLE
Add available order variable to collection tag

### DIFF
--- a/content/collections/tags/collection.md
+++ b/content/collections/tags/collection.md
@@ -126,6 +126,11 @@ variables:
     description: >
       The number/index of current iteration in the loop, starting from 0
   -
+    name: order
+    type: integer
+    description: >
+      The number/index of the item relative to the collection, not affected by any sort/filter parameters on the tag. Note: this is only available on collections where the order is set to number.
+  -
     name: no_results
     type: boolean
     description: Returns true if there are no results.


### PR DESCRIPTION
When trying to access the number of a collection's item (where order is set to number and not date), you can use `{{ order }}`. Slightly different than `index` or `zero_index` because it is not in context of the current loop, but of the original collection. I guess it would be similar to `{{ date }}` on a date-based collection.