### PR TITLE
Update obfuscate.md

### DIFF
--- a/content/collections/tags/obfuscate.md
+++ b/content/collections/tags/obfuscate.md
@@ -18,3 +18,7 @@ description: Obfuscate content (usually email addresses) to prevent screenscrapi
 # output appears as heisenberg@example.com
 he&#x69;se&#x6e;&#x62;&#x65;&#114;&#103;@&#101;&#120;a&#109;&#x70;&#x6c;&#x65;&#x2e;c&#x6f;&#109;
 ```
+
+### Tip:
+
+If you have chosen to use EMail addresses for logging in users (which means `{{ username }}` is a member's  email address), and you want to create a `mailto:` link, you need to use obfuscate's modifier form, as in:  `<a href="mailto:%22{{ first_name }}%20{{ last_name }}%22%20%3C{{ username | obfuscate }}%3E" >`. 


### PR DESCRIPTION
Per convo from Discord: 
iDGSToday at 11:26 AM
After I converted to using email addresses as usernames, I'm now updating mailto: links, and within them I can't seem to get this to work: …{{ obfuscate }}{{ username }}{{ /obfuscate }}….  Instead of what I want (the email address), I'm getting {{ username }} as the text inside the email link. However, if  I take out the obfuscate bookends, around {{ username }} it works just fine. I get the email address within the mailto: link, just like I wanted. I tried single braces, like so, …{{ obfuscate }}{ username }{{ /obfuscate }}… but no joy. Should I just forget about using obfuscate?  Or...?(edited)
NVM. The trick was to use the modifier, as in {{ username | obfuscate }} and not the enclosing tags. :face_palm:
NEW MESSAGES
CullenToday at 11:43 AM
god to know, thanks for posting the solution. @iDGS