### PR TITLE
Added guidance to Glide docs about Locales

### DIFF
--- a/content/collections/tags/glide.md
+++ b/content/collections/tags/glide.md
@@ -223,3 +223,7 @@ image_manipulation_cached_path: img
 # The URL to the folder
 image_manipulation_route: img
 ```
+
+## Using Glide with Locales {#glide-and-locales}
+
+When using Glide with multiple locales, the generated image path will include the proper `site_root` as dictated by the locale, but the actual asset will be stored wherever you have set the `image_manipulation_cached_path`. To serve these assets when on a localized version, you'll need to create a symlink from your `/$locale/image_manipulation_cached_path` to `image_manipulation_cached_path`. 


### PR DESCRIPTION
per convos described here: https://github.com/statamic/v2-hub/issues/1440 just a little helping hand in regards to the glide path generated when in a locale that's not the default. 

Wasn't sure if this belonged in the Localization docs or here, but felt like someone would be searching here first when running into a glide issue.