### PR TITLE
Clarify how Assets are saved when max_files is 1

### DIFF
--- a/content/collections/fieldtypes/assets.md
+++ b/content/collections/fieldtypes/assets.md
@@ -18,7 +18,7 @@ options:
   -
     name: max_files
     type: int
-    description: The maximum number of allowed files. If left blank, there will be no limit.
+    description: The maximum number of allowed files. If left blank, there will be no limit. If set to 1, the asset will be saved as a string instead of an array
   -
     name: restrict
     type: bool


### PR DESCRIPTION
Just to help people in the future know that the data is saved differently when this option is set.