### PR TITLE
Path for S3 example

### DIFF
--- a/content/collections/docs/assets.md
+++ b/content/collections/docs/assets.md
@@ -286,6 +286,7 @@ bucket:  # The bucket name
 region:  # The region code (eg. us-west-1)
 path:    # A subfolder of the bucket, if you'd like
 cache:   # A cache time in seconds. More info below.
+url:     # URL prefix
 ```
 
 The region codes can be tough to remember. [Here’s a list of them.](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)


### PR DESCRIPTION
Not sure if I am missing something but when trying to connect to an existing S3 bucket for a site I'm moving to Statamic things were not working until I added the `url` parameter with my public S3 prefix. If I am missing something would be glad to know.