### PR TITLE
fix typo

### DIFF
--- a/content/collections/modifiers/reverse.md
+++ b/content/collections/modifiers/reverse.md
@@ -21,6 +21,6 @@ order_of_ceremony:
 ```
 
 ```.language-output
-diapers
+diaper
 party, eat, service, photos
 ```


### PR DESCRIPTION
diaper (without the 's') is the reverse of repaid.

Removing the 's'