### PR TITLE
Add .webp as a supported value for "format"

### DIFF
--- a/content/collections/tags/glide.md
+++ b/content/collections/tags/glide.md
@@ -73,7 +73,7 @@ shape:
     name: format
     type: string *jpg*
     description: >
-      Encodes the image to a specific format. Accepts `jpg`, `pjpg` (progressive jpeg), `png` or `gif`.
+      Encodes the image to a specific format. Accepts `jpg`, `pjpg` (progressive jpeg), `png`, `gif` or `webp`.
 
 filters:
   -


### PR DESCRIPTION
This functionality was implemented in 2.11.13. I tested locally and confirmed that it works.