### PR TITLE
Removed an extra "s" in the foreach:address tag.

### DIFF
--- a/content/collections/fieldtypes/array.md
+++ b/content/collections/fieldtypes/array.md
@@ -87,5 +87,5 @@ Foreach tag:
 ```
 {{ foreach:address }}
     {{ key }}: {{ value }}
-{{ /foreach:addresss }}
+{{ /foreach:address }}
 ```


### PR DESCRIPTION
The foreach tag contained an extra 's' in the closing foreach tag. 
{{ /foreach:addresss }} => {{ /foreach:address }}