### PR TITLE
Asset Tag: Correct parameter name

### DIFF
--- a/content/collections/tags/assets.md
+++ b/content/collections/tags/assets.md
@@ -154,7 +154,7 @@ bacon_images:
 
 ### Single Assets {#single-assets}
 
-If you have an asset field with `max_items: 1` the data will be saved as a `string`. As one cannot iterate over a string, the tag will adjust accordingly without complaining.
+If you have an asset field with `max_files: 1` the data will be saved as a `string`. As one cannot iterate over a string, the tag will adjust accordingly without complaining.
 
 ``` .language-yaml
 hero_image: /img/negasonic-teenage-warhead.jpg


### PR DESCRIPTION
Asset Tag Doc suggests to use parameter `max_items` to store singe file as value (instead of list) which does not seem to work. 

I corrected the doc to `max_files` - which works as expected - as documented here: https://docs.statamic.com/fieldtypes/assets